### PR TITLE
security(PS-1634): remove T-Mobile customer name references from work…

### DIFF
--- a/discovery-airgap/config-stg/namespace-labeler.yaml
+++ b/discovery-airgap/config-stg/namespace-labeler.yaml
@@ -56,6 +56,11 @@ spec:
               declare -a labels_arr=(
               )
 
+              if [ ${#labels_arr[@]} -eq 0 ]; then
+                echo "$(date) No namespace labels configured; exiting without changes"
+                exit 0
+              fi
+
               declare -a spectro_namespaces_arr=(
               "cert-manager" "capi-kubeadm-bootstrap-system"
               "capi-kubeadm-control-plane-system" "capi-webhook-system"

--- a/discovery-airgap/config-stg/namespace-labeler.yaml
+++ b/discovery-airgap/config-stg/namespace-labeler.yaml
@@ -54,8 +54,6 @@ spec:
             - |
 
               declare -a labels_arr=(
-              "k8s.t-mobile.com/akmid=APM0103270"
-              "k8s.t-mobile.com/director=RMcguir4"
               )
 
               declare -a spectro_namespaces_arr=(

--- a/discovery-airgap/config/namespace-labeler.yaml
+++ b/discovery-airgap/config/namespace-labeler.yaml
@@ -56,6 +56,11 @@ spec:
               declare -a labels_arr=(
               )
 
+              if [ ${#labels_arr[@]} -eq 0 ]; then
+                echo "$(date) No namespace labels configured; exiting without changes"
+                exit 0
+              fi
+
               declare -a spectro_namespaces_arr=(
               "cert-manager" "capi-kubeadm-bootstrap-system"
               "capi-kubeadm-control-plane-system" "capi-webhook-system"

--- a/discovery-airgap/config/namespace-labeler.yaml
+++ b/discovery-airgap/config/namespace-labeler.yaml
@@ -54,8 +54,6 @@ spec:
             - |
 
               declare -a labels_arr=(
-              "k8s.t-mobile.com/akmid=APM0103270"
-              "k8s.t-mobile.com/director=RMcguir4"
               )
 
               declare -a spectro_namespaces_arr=(

--- a/discovery/config-stg/namespace-labeler.yaml
+++ b/discovery/config-stg/namespace-labeler.yaml
@@ -67,6 +67,11 @@ spec:
               declare -a labels_arr=(
               )
 
+              if [ ${#labels_arr[@]} -eq 0 ]; then
+                echo "$(date) No namespace labels configured; exiting without changes"
+                exit 0
+              fi
+
               declare -a spectro_namespaces_arr=(
               "cert-manager" "capi-kubeadm-bootstrap-system"
               "capi-kubeadm-control-plane-system" "capi-webhook-system"

--- a/discovery/config-stg/namespace-labeler.yaml
+++ b/discovery/config-stg/namespace-labeler.yaml
@@ -65,8 +65,6 @@ spec:
             - |
 
               declare -a labels_arr=(
-              "k8s.t-mobile.com/akmid=APM0103270"
-              "k8s.t-mobile.com/director=RMcguir4"
               )
 
               declare -a spectro_namespaces_arr=(

--- a/discovery/config/namespace-labeler.yaml
+++ b/discovery/config/namespace-labeler.yaml
@@ -67,6 +67,11 @@ spec:
               declare -a labels_arr=(
               )
 
+              if [ ${#labels_arr[@]} -eq 0 ]; then
+                echo "$(date) No namespace labels configured; exiting without changes"
+                exit 0
+              fi
+
               declare -a spectro_namespaces_arr=(
               "cert-manager" "capi-kubeadm-bootstrap-system"
               "capi-kubeadm-control-plane-system" "capi-webhook-system"

--- a/discovery/config/namespace-labeler.yaml
+++ b/discovery/config/namespace-labeler.yaml
@@ -65,8 +65,6 @@ spec:
             - |
 
               declare -a labels_arr=(
-              "k8s.t-mobile.com/akmid=APM0103270"
-              "k8s.t-mobile.com/director=RMcguir4"
               )
 
               declare -a spectro_namespaces_arr=(

--- a/discovery/modules/tke-cluster/cluster.tf
+++ b/discovery/modules/tke-cluster/cluster.tf
@@ -61,11 +61,6 @@ resource "spectrocloud_cluster_vsphere" "this" {
     control_plane = true
     name          = "master-pool"
     count         = 1
-    #additional_labels = {
-      #"k8s.t-mobile.com/cmdb_app_id" = "APP0005963",
-      #"k8s.t-mobile.com/cmdb_app" = "TKE-test"
-    #}
-
     dynamic "placement" {
       for_each = local.placements
       content {
@@ -87,9 +82,6 @@ resource "spectrocloud_cluster_vsphere" "this" {
     for_each = ["wp-az1","wp-az2","wp-az3"]
     content {
       name  = machine_pool.value
-      additional_labels = {
-        "k8s.t-mobile.com/cmdb_app_id" = "APP0005963"
-      }
       count = var.cluster_workers_per_az
       placement {
         cluster           = local.placements[machine_pool.key].cluster


### PR DESCRIPTION
…ing tree

Removes all hardcoded T-Mobile references from live configuration files as required by PS-1634 (bug bounty report - customer attribution exposure).

Files remediated:
- discovery/modules/tke-cluster/cluster.tf
- discovery/config/namespace-labeler.yaml
- discovery/config-stg/namespace-labeler.yaml
- discovery-airgap/config/namespace-labeler.yaml
- discovery-airgap/config-stg/namespace-labeler.yaml

Git history purge (all branches) to follow as a separate step.